### PR TITLE
Moving DeveloperTools into .github repo [[Finalized]]

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - reuseable-workflow
 
 jobs:
   Build-Documentation:

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -1,0 +1,13 @@
+name: Build and Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+      - reuseable-workflow
+
+jobs:
+  Build-Documentation:
+    uses: NWChemEx-Project/.github/.github/workflows/deploy_docs_tmpl.yml@master
+    with: 
+      dependencies: sphinx
+      skip_doxygen: true

--- a/.github/workflows/test_docs.yaml
+++ b/.github/workflows/test_docs.yaml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - reuseable-workflow
 
 jobs:
   Build-Documentation:

--- a/.github/workflows/test_docs.yaml
+++ b/.github/workflows/test_docs.yaml
@@ -1,0 +1,15 @@
+name: Test Documentation
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - reuseable-workflow
+
+jobs:
+  Build-Documentation:
+    uses: NWChemEx-Project/.github/.github/workflows/test_docs_tmpl.yml@master
+    with:
+      dependencies: sphinx
+      skip_doxygen: true


### PR DESCRIPTION
**Ready to be merged!!!**

We moved the deploy_docs.yaml and test_docs.yaml workflows from DeveloperTools repo to .github repo.