### PR TITLE
Fix python_defines required

### DIFF
--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -69,7 +69,7 @@ function(cppyy_make_python_package)
     set(python_defines_file "${output_dir}/python_defines.hpp")
     set(python_defines "#define MADNESS_HAS_CEREAL\n")
     if(BTAS_USE_BLAS_LAPACK)
-        set(python_defines "#define BTAS_HAS_BLAS_LAPACK\n")
+        set(python_defines "${python_defines}#define BTAS_HAS_BLAS_LAPACK\n")
     endif()
     file(GENERATE OUTPUT ${python_defines_file} CONTENT "${python_defines}")
     #---------------------------------------------------------------------------


### PR DESCRIPTION
When BTAS_USE_BLAS_LAPACK is true MADNESS_HAS_CEREAL is not defined and it causes an error when ParallelZone Python bindings are required.

This PR fixes this problem.