### PR TITLE
Update cppyy

### DIFF
--- a/cmake/FindCppyy.cmake
+++ b/cmake/FindCppyy.cmake
@@ -4,7 +4,7 @@
 #
 # Set minimal cppyy version
 #
-set(cppyy_version "2.4.0")
+set(cppyy_version "2.4.1")
 #
 # Make sure Python3 is installed
 #
@@ -13,34 +13,60 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # Check if cppyy Python package exists
 #
 execute_process(
-    COMMAND Python3::Interpreter -c "import cppyy"
-    RESULT_VARIABLE _fcppyy_result
+    COMMAND ${Python3_EXECUTABLE} -c "import cppyy"
+    OUTPUT_VARIABLE _fcppyy_result
 )
 #
 # If cppyy exists, check version
 #
 if("${_fcppyy_result}" STREQUAL "")
+    set(Cppyy_FOUND TRUE)
     execute_process(
-        COMMAND Python3::Interpreter -c "import cppyy; print(cppyy.__version__)"
-        RESULT_VARIABLE _fcppyy_result2
+        COMMAND ${Python3_EXECUTABLE} -c "import cppyy; print(cppyy.__version__),"
+        OUTPUT_VARIABLE _fcppyy_result2
     )
+else()
+    set(Cppyy_FOUND FALSE)
 endif()
 #
 # Try to install cppyy Python package, if it doesn't exist or is incorrect version
 #
-if(NOT "${_fcppyy_result}" STREQUAL "" OR NOT "${_fcppyy_result2}" STREQUAL "${cppyy_version}")
+if("${_fcppyy_result}" STREQUAL "" OR NOT "${_fcppyy_result2}" VERSION_EQUAL "${cppyy_version}")
     if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
-      set(_pip_args)
+        set(_pip_args)
     else()
-      set(_pip_args "--user")
+        set(_pip_args "--user")
     endif()
     set(_pypkg_name "cppyy==${cppyy_version}")
     execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install ${_pypkg_name} ${_pip_args})
     #
     # Check again if cppyy Python works
     #
-    execute_process(COMMAND Python3::Interpreter -c "import cppyy" RESULT_VARIABLE _fcppyy_result)
-    if(NOT "${_fcppyy_result}" STREQUAL "")
-       set(Cppyy_FOUND FALSE)
+    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import cppyy" OUTPUT_VARIABLE _fcppyy_result)
+    if("${_fcppyy_result}" STREQUAL "")
+        set(Cppyy_FOUND TRUE)
+    	execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import cppyy; print(cppyy.__version__),"
+        	OUTPUT_VARIABLE _fcppyy_result2
+    	)
+    else()
+        set(Cppyy_FOUND FALSE)
     endif()
+    #
+    # Check the version again
+    #
+    if("${_fcppyy_result2}" VERSION_EQUAL "${cppyy_version}")
+        set(Cppyy_FOUND TRUE)
+    else()
+        set(Cppyy_FOUND FALSE)
+    endif()
+else()
+    set(Cppyy_FOUND TRUE)
+endif()
+
+if(NOT Cppyy_FOUND)
+    message("Python3: ${Python3_EXECUTABLE}")
+    message("import output: ${_fcppyy_result}")
+    message("version output: ${_fcppyy_result2}")
+    message(FATAL_ERROR "CMake could not install cppyy, try installing cppyy ${cppyy_version} manually.")
 endif()

--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -46,7 +46,6 @@ function(cppyy_make_python_package)
     #---------------------------------------------------------------------------
     get_true_target_property(include_dirs ${install_data_PACKAGE} INTERFACE_INCLUDE_DIRECTORIES)
     list(APPEND include_dirs ${MPI_CXX_HEADER_DIR})
-    list(APPEND include_dirs ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
     list(REMOVE_DUPLICATES include_dirs)
     #---------------------------------------------------------------------------
     #--------------------------Get headers to include---------------------------


### PR DESCRIPTION
* Disable including implicit directories, which creates problems with IntelLLVM.
* Update cppyy to 2.4.1.
* Attempt to fix #26, works at least for [this](https://github.com/NWChemEx-Project/ParallelZone/issues/84#issuecomment-1363189964) case.

TODO:
`.cmake` files are not synced anymore, see issue #48. Should we enable sync or move them to a new repo or to CmakePP?