### PR TITLE
Update add_licenses_master.yaml

### DIFF
--- a/.github/workflows/add_licenses_master.yaml
+++ b/.github/workflows/add_licenses_master.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Apply Licenses
-        uses: apache/skywalking-eyes@main
+        uses: apache/skywalking-eyes@v0.4.0
         with:
           config: ${{ inputs.config_file }}
           mode: fix


### PR DESCRIPTION
This PR pins the version of the licensing action. In the CMakePP organization this seems to avoid the licensing action re-licensing all of the files when the year changes. 

This PR is r2g.