### PR TITLE
Build Dodule Docs

### DIFF
--- a/.github/workflows/deploy_docs_tmpl.yaml
+++ b/.github/workflows/deploy_docs_tmpl.yaml
@@ -9,6 +9,11 @@ on:
         type: string
       skip_doxygen:
         type: boolean
+      generate_modules_docs:
+        type: boolean
+    secrets:
+      CMAIZE_GITHUB_TOKEN:
+        type: string
 jobs:
   Build-Documentation:
     runs-on: ubuntu-latest
@@ -27,6 +32,8 @@ jobs:
         with:
           target: ${{inputs.target}}
           skip_doxygen: ${{inputs.skip_doxygen}}
+          generate_modules_docs: ${{inputs.generate_modules_docs}}
+          CMAIZE_GITHUB_TOKEN: ${{inputs.CMAIZE_GITHUB_TOKEN}}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/test_docs_tmpl.yaml
+++ b/.github/workflows/test_docs_tmpl.yaml
@@ -9,6 +9,11 @@ on:
         type: string
       skip_doxygen:
         type: boolean
+      generate_modules_docs:
+        type: boolean
+    secrets:
+      CMAIZE_GITHUB_TOKEN:
+        type: string
       
 jobs:
   build-documentation:
@@ -32,3 +37,5 @@ jobs:
       with:
         target: ${{inputs.target}}
         skip_doxygen: ${{inputs.skip_doxygen}}
+        generate_modules_docs: ${{inputs.generate_modules_docs}}
+        CMAIZE_GITHUB_TOKEN: ${{inputs.CMAIZE_GITHUB_TOKEN}}

--- a/actions/build/build.sh
+++ b/actions/build/build.sh
@@ -35,6 +35,8 @@ echo "set(BUILD_TESTING ON)" > "${toolchain_file}"
   echo 'set(BLAS_LIBRARIES   "-L${LIBDIR} -lopenblas")'
   echo 'set(LAPACK_LIBRARIES "-L${LIBDIR} -llapack ${BLAS_LIBRARIES}")'
   echo 'set(ScaLAPACK_LIBRARIES  "-L${LIBDIR} -lscalapack-openmpi ${LAPACK_LIBRARIES}")'
+  echo 'set(BUILD_PYBIND11_PYBINDINGS ON)'
+  echo 'set(NWX_MODULE_DIRECTORY "./NWX_PyModules")'
 } >> "${toolchain_file}"
 
 # if clang_version is not empty set clang and 

--- a/actions/build_docs/action.yaml
+++ b/actions/build_docs/action.yaml
@@ -4,6 +4,10 @@ inputs:
     type: string
   skip_doxygen:
     type: boolean
+  generate_modules_docs:
+    type: boolean
+  CMAIZE_GITHUB_TOKEN:
+    type: string
 runs:
   using: "composite"
   steps:
@@ -13,6 +17,25 @@ runs:
     - name: Build Documentation
       if: ${{ inputs.skip_doxygen == 'false' }} 
       run: ${{github.action_path}}/build_docs.sh ${{inputs.target}}
+      shell: bash
+    - name: Generate Module Documentation
+      if: ${{ inputs.skip_doxygen == 'true' }}
+      env:
+        CMAIZE_GITHUB_TOKEN: ${{inputs.CMAIZE_GITHUB_TOKEN}}
+      run:  |
+        # First, we need to build the full application
+        chmod +x ${{github.action_path}}/../build/build.sh
+        ${{github.action_path}}/../build/build.sh
+
+        # Next, we generate the module docs
+        . venv/bin/activate
+        PYTHONPATH="${PYTHONPATH}:/build"
+        if [ -d "./build/_deps/pluginplay-build" ]; then
+          PYTHONPATH="${PYTHONPATH}:/build/_deps/pluginplay-build"
+        fi
+        python ${{github.action_path}}/generate_module_dox.py ${{inputs.target}}
+        deactivate
+
       shell: bash
     - name: Give Permission to build_sphinx_docs.sh
       run: chmod +x ${{github.action_path}}/build_sphinx_docs.sh 

--- a/actions/build_docs/generate_module_dox.py
+++ b/actions/build_docs/generate_module_dox.py
@@ -1,0 +1,46 @@
+import sys
+import importlib
+
+"""This script will generate the module api documentation for a plugin library.
+
+Usage
+-----
+
+::
+
+   usage: generate_module_dox.py library_name
+
+   positional arguments:
+     library_name  The name of the library for which the documentation is 
+                   supposed to be generated.
+
+This script checks that only one library name is passed and that it can import
+pluginplay and the library specified. If the library is a plugin, a module
+manager if constructed and the modules of the library are loaded into it.
+The document_modules is called on the manager.
+"""
+
+if __name__ == "__main__":
+    # Exit if more than a single argument is passed
+    if len(sys.argv) != 2:
+        sys.exit()
+
+    # Can we find pluginplay? If not, exit
+    try:
+        pluginplay = importlib.import_module("pluginplay")
+    except Exception:
+        sys.exit()
+
+    # Can we find the library to document? If not, exit
+    try:
+        library = importlib.import_module(sys.argv[1])
+    except Exception:
+        sys.exit()
+
+    # If this library is a plugin, print the dox
+    if hasattr(library, "load_modules"):
+        mm = pluginplay.ModuleManager()
+        library.load_modules(mm)
+        # This is no-op if docs/source/module_api doesn't exist
+        pluginplay.document_modules(mm, "docs/source/module_api")
+

--- a/actions/build_docs/generate_module_dox.py
+++ b/actions/build_docs/generate_module_dox.py
@@ -24,23 +24,18 @@ if __name__ == "__main__":
     # Exit if more than a single argument is passed
     if len(sys.argv) != 2:
         sys.exit()
+    target = sys.argv[1].replace("_cxx_api", "")
 
-    # Can we find pluginplay? If not, exit
+    # Exit on any exception
     try:
         pluginplay = importlib.import_module("pluginplay")
+        library = importlib.import_module(target)
+        # If this library is a plugin, try to print the dox.
+        if hasattr(library, "load_modules"):
+            mm = pluginplay.ModuleManager()
+            library.load_modules(mm)
+            # This is no-op if docs/source/module_api doesn't exist
+            pluginplay.document_modules(mm, "docs/source/module_api")
     except Exception:
         sys.exit()
-
-    # Can we find the library to document? If not, exit
-    try:
-        library = importlib.import_module(sys.argv[1])
-    except Exception:
-        sys.exit()
-
-    # If this library is a plugin, print the dox
-    if hasattr(library, "load_modules"):
-        mm = pluginplay.ModuleManager()
-        library.load_modules(mm)
-        # This is no-op if docs/source/module_api doesn't exist
-        pluginplay.document_modules(mm, "docs/source/module_api")
 


### PR DESCRIPTION
**PR Type**
- [ ] Breaking change
- [x] Feature
- [x] Patch

**Brief Description**
This PR adds the option to build the module documentation for plugin libraries. It extends `deploy_docs_tmpl` and `test_docs_tmpl` with the `generate_modules_docs` input, which is off by default. The `CMAIZE_GITHUB_TOKEN` is also added as on optional input, but it is necessary when the module docs are intended to be built. These changes should be opt-in, so they shouldn't break anything.

**Not In Scope**

**PR Checklist**

- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [ ] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
