### PR TITLE
Clear Build Dir Between Docs Build Steps

### DIFF
--- a/actions/build_docs/action.yaml
+++ b/actions/build_docs/action.yaml
@@ -24,6 +24,7 @@ runs:
         CMAIZE_GITHUB_TOKEN: ${{inputs.CMAIZE_GITHUB_TOKEN}}
       run:  |
         # First, we need to build the full application
+        rm -rf ./build/
         chmod +x ${{github.action_path}}/../build/build.sh
         ${{github.action_path}}/../build/build.sh
 


### PR DESCRIPTION
**PR Type**
- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
Clears the build directory between steps in `build_docs` to ensure the full library is built when needed.

**Not In Scope**

**PR Checklist**

- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [x] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
