### PR TITLE
Adds "edit on GitHub" to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,9 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'vcs_pageview_mode' : 'edit'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -103,6 +105,14 @@ html_theme = 'sphinx_rtd_theme'
 #
 # html_sidebars = {}
 
+
+# Allows the edit on GitHub button to make editing the docs easier.
+html_context = {
+  'display_github': True,
+  'github_user': 'NWChemEx-Project',
+  'github_repo': '.github',
+  'github_version': 'master/docs/source/',
+}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/source/resources/recommended_development_resources.rst
+++ b/docs/source/resources/recommended_development_resources.rst
@@ -1,12 +1,13 @@
-*********************************
+#################################
 Recommended Development Resources
-*********************************
+#################################
 
 The point of this page is to collect a list of recommended programs,
 applications, and websites for performing development tasks.
 
+**************************
 Naming Libraries and Repos
---------------------------
+**************************
 
 https://namelix.com
    Namelix uses AI to generate possible names for your package. You provide
@@ -14,8 +15,9 @@ https://namelix.com
    results. You can customize the length and style (mispellings, rhyming words,
    *etc.*) of the generated names.
 
+******************************
 Drawing Documentation Diagrams
-------------------------------
+******************************
 
 https://excalidraw.com
    Excalidraw has an easy to use API which allows you to quickly draw UML-like
@@ -23,3 +25,14 @@ https://excalidraw.com
    for the diagram in the image so you can modify it later). Another cool
    feature is that you can share the diagram with other people and you can all
    work on the diagram in real time.
+
+**************************************
+Creating ASCII File Structure Diagrams
+**************************************
+
+https://ascii-tree-generator.com/
+   This is a simple web app which provides a GUI that acts like a file browser.
+   In the GUI you can create folders and files and drag them around to nest
+   them. The app then generates an ASCII representation of the file system which
+   you can then copy/paste into documentation (or wherever else you want to
+   put the diagram).


### PR DESCRIPTION
When reading documentation on the internet one often thinks of little edits that could make the documentation better. To lower the barrier to making such edits this PR modifies the HTML documentation so that all pages have an "edit on GitHub" link. When a user clicks this link they'll be taken directly to an editor on GitHub with the source for that page. They can then make their changes, and launch a PR with those changes.

This came about because I wanted to add an additional resource to our "Recommended Development Resources" for generating ASCII file system diagrams. So in addition to modifying the configuration of the documentation, this PR also adds that link and description.