### PR TITLE
Repo Toolchain

### DIFF
--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -41,7 +41,7 @@ on:
         required: false
         default: ''
       repo_toolchain:
-        description: "A CMake toolchain for repo specific settings"
+        description: "Path (from repo root) to a CMake toolchain for repo specific settings"
         type: string
         required: false
         default: ''
@@ -118,7 +118,7 @@ jobs:
         if: repo_toolchain != ''
         run:  |
           toolchain=/toolchains/nwx_${{ matrix.compiler }}.cmake
-          echo 'include(${{ inputs.repo_toolchain }})' >> $toolchain
+          echo 'include('${PWD}'/${{ inputs.repo_toolchain }})' >> $toolchain
         shell: bash
       - name: Build and Test
         env:

--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Append Repo Settings to CMake Toolchain
-        if: repo_toolchain != ''
+        if: inputs.repo_toolchain != ''
         run:  |
           toolchain=/toolchains/nwx_${{ matrix.compiler }}.cmake
           echo 'include('${PWD}'/${{ inputs.repo_toolchain }})' >> $toolchain

--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -40,6 +40,11 @@ on:
         type: string
         required: false
         default: ''
+      repo_toolchain:
+        description: "A CMake toolchain for repo specific settings"
+        type: string
+        required: false
+        default: ''
       doc_target:
         description: "The name of the documentation target. Set to 'Sphinx' to skip doxygen"
         type: string
@@ -109,6 +114,12 @@ jobs:
         compiler: ${{ fromJSON(inputs.compilers) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Append Repo Settings to CMake Toolchain
+        if: repo_toolchain != ''
+        run:  |
+          toolchain=/toolchains/nwx_${{ matrix.compiler }}.cmake
+          echo 'include(${{ inputs.repo_toolchain }})' >> $toolchain
+        shell: bash
       - name: Build and Test
         env:
           CMAIZE_GITHUB_TOKEN: ${{secrets.CMAIZE_GITHUB_TOKEN}}


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [x] Feature
- [ ] Patch

**Brief Description**
Adds an additional, optional input to the `common_pr_workflow.yaml` to provide a repo specific CMake toolchain file that is appended to the toolchain inside the testing environment. The path to the additional toolchain file is expected to be relative to the root directory of the current repository. 

**Not In Scope**

**PR Checklist**

- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [x] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
